### PR TITLE
Add - failWithError to WVPResponse to allow proxying network failures

### DIFF
--- a/WebViewProxy/WebViewProxy.h
+++ b/WebViewProxy/WebViewProxy.h
@@ -20,9 +20,10 @@ typedef void (^StopLoadingHandler)();
 - (void) respondWithJSON:(NSDictionary*)jsonObject;
 - (void) handleStopLoadingRequest:(StopLoadingHandler)stopLoadingHandler;
 // Low level API
-- (void) respondWithError:(NSInteger)statusCode text:(NSString*)text;
 - (void) setHeader:(NSString*)headerName value:(NSString*)headerValue;
 - (void) setHeaders:(NSDictionary*)headers;
+- (void) failWithError:(NSError*)connectionError;
+- (void) respondWithError:(NSInteger)statusCode text:(NSString*)text;
 - (void) respondWithData:(NSData*)data mimeType:(NSString*)mimeType;
 - (void) respondWithData:(NSData*)data mimeType:(NSString*)mimeType statusCode:(NSInteger)statusCode;
 // Pipe data API

--- a/WebViewProxy/WebViewProxy.m
+++ b/WebViewProxy/WebViewProxy.m
@@ -88,11 +88,16 @@ static NSPredicate* webViewProxyLoopDetection;
         [self setHeader:headerName value:headers[headerName]];
     }
 }
+
+- (void)failWithError:(NSError *)connectionError
+{
+    [_protocol.client URLProtocol:_protocol didFailWithError:connectionError];
+}
+
 - (void)respondWithData:(NSData *)data mimeType:(NSString *)mimeType {
     [self respondWithData:data mimeType:mimeType statusCode:200];
 }
 - (void)respondWithError:(NSInteger)statusCode text:(NSString *)text {
-    // TODO We need to add an error responder to signal a network error, as opposed to an HTTP error
     NSData* data = [text dataUsingEncoding:NSUTF8StringEncoding];
     [self respondWithData:data mimeType:@"text/plain" statusCode:statusCode];
 }


### PR DESCRIPTION
Using the previously available `respondWithError:text:` method, it's not possible to proxy network failures through to the web view as expected. By adding a method to call the client's `didFailWithError:` method, we can simply passing the connection error right on through, and things behave as expected.

I didn't remove the other method, because that's a backwards incompatible change and figured you'd want to handle that in your own time.
