### PR TITLE
Fix potentially infinite loop

### DIFF
--- a/WebViewProxy/WebViewProxy.m
+++ b/WebViewProxy/WebViewProxy.m
@@ -273,7 +273,7 @@ static NSPredicate* webViewProxyLoopDetection;
 + (void)initialize {
     [WebViewProxy removeAllHandlers];
     webViewUserAgentTest = [NSPredicate predicateWithFormat:@"self MATCHES '^Mozilla.*Mac OS X.*'"];
-    webViewProxyLoopDetection = [NSPredicate predicateWithFormat:@"self.fragment MATCHES '__webviewproxyreq__'"];
+    webViewProxyLoopDetection = [NSPredicate predicateWithFormat:@"self.fragment ENDSWITH '__webviewproxyreq__'"];
     // e.g. "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A403"
     [NSURLProtocol registerClass:[WebViewProxyURLProtocol class]];
 }


### PR DESCRIPTION
Fix the pb on fonts.gstatic.com who add fragment to his URL. So when a fragment is present, the MATCHES dont find the loop detection token and the proxy fall in an infinite loop (at least, we can keep MATCHES with this regexp '.***webviewproxyreq**').
